### PR TITLE
UglifyJS JavaScript compressor compatibility

### DIFF
--- a/jquery-scrollspy.js
+++ b/jquery-scrollspy.js
@@ -3,8 +3,6 @@
  * Author: @sxalexander
  * Licensed under the MIT license
  */
-
-
 ;(function ( $, window, document, undefined ) {
 
     $.fn.extend({
@@ -95,4 +93,4 @@
     })
 
     
-})( jQuery, window );
+})( jQuery, window, document, undefined );


### PR DESCRIPTION
When uglify process the scrollspy, there was an error because document
was replaced in function parameters at line 6 by a small variable name.
Reference to document object was lost until it is given in function
call at line 96
